### PR TITLE
When hiding tab bar via command-line parameter, don't affect settings.

### DIFF
--- a/PowerEditor/src/Notepad_plus_Window.cpp
+++ b/PowerEditor/src/Notepad_plus_Window.cpp
@@ -124,7 +124,13 @@ void Notepad_plus_Window::init(HINSTANCE hInst, HWND parent, const TCHAR *cmdLin
 	
 	if (cmdLineParams->_isNoTab || (nppGUI._tabStatus & TAB_HIDE))
 	{
+		const int tabStatusOld = nppGUI._tabStatus;
 		::SendMessage(_hSelf, NPPM_HIDETABBAR, 0, TRUE);
+		if (cmdLineParams->_isNoTab)
+		{
+			// Restore old settings when tab bar has been hidden from tab bar.
+			nppGUI._tabStatus = tabStatusOld;
+		}
 	}
 
 	if (cmdLineParams->_alwaysOnTop)


### PR DESCRIPTION
Passing -notabbar changes the settings. I would expect command-line arguments to only affect one session of the program.

There are a couple of ways of solving this, but to keep NPPM_HIDETABBAR backwards compatible I chose to restore the setting in the init function it is changed.

http://sourceforge.net/p/notepad-plus/bugs/5274/