### PR TITLE
Replaced single use of lstrcpy in PluginsManager.cpp

### DIFF
--- a/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
+++ b/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
@@ -142,7 +142,7 @@ int PluginsManager::loadPlugin(const TCHAR *pluginFilePath, vector<generic_strin
 			}
 
 			TCHAR xmlPath[MAX_PATH];
-            lstrcpy(xmlPath, nppParams->getNppPath().c_str());
+            _tcscpy_s(xmlPath, nppParams->getNppPath().c_str());
 			PathAppend(xmlPath, TEXT("plugins\\Config"));
             PathAppend(xmlPath, pi->_moduleName.c_str());
 			PathRemoveExtension(xmlPath);


### PR DESCRIPTION
["lstrcpy is a similarly named Microsoft design defect that appears to behave like strlcpy but is actually a security bug."](https://randomascii.wordpress.com/2013/04/03/stop-using-strncpy-already/)

["Copies a string to a buffer. **Warning**: Do not use."](https://msdn.microsoft.com/en-us/library/windows/desktop/ms647490.aspx)