### PR TITLE
fixed misaligned OPENFILENAMENPP struct

### DIFF
--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/FileDialog.cpp
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/FileDialog.cpp
@@ -171,18 +171,12 @@ TCHAR * FileDialog::doOpenSingleFileDlg()
 	_ofn.Flags |= OFN_FILEMUSTEXIST;
 
 	TCHAR *fn = NULL;
-	try {
-		fn = ::GetOpenFileName((OPENFILENAME*)&_ofn)?_fileName:NULL;
+	fn = ::GetOpenFileName(reinterpret_cast<OPENFILENAME*>(&_ofn))?_fileName:NULL;
 		
-		if (params->getNppGUI()._openSaveDir == dir_last)
-		{
-			::GetCurrentDirectory(MAX_PATH, dir);
-			params->setWorkingDir(dir);
-		}
-	} catch(std::exception e) {
-		::MessageBoxA(NULL, e.what(), "Exception", MB_OK);
-	} catch(...) {
-		::MessageBox(NULL, TEXT("GetSaveFileName crashes!!!"), TEXT(""), MB_OK);
+	if (params->getNppGUI()._openSaveDir == dir_last)
+	{
+		::GetCurrentDirectory(MAX_PATH, dir);
+		params->setWorkingDir(dir);
 	}
 
 	::SetCurrentDirectory(dir); 
@@ -252,17 +246,11 @@ TCHAR * FileDialog::doSaveDlg()
 	_ofn.lpfnHook = OFNHookProc;
 
 	TCHAR *fn = NULL;
-	try {
-		fn = ::GetSaveFileName((OPENFILENAME*)&_ofn)?_fileName:NULL;
-		if (params->getNppGUI()._openSaveDir == dir_last)
-		{
-			::GetCurrentDirectory(MAX_PATH, dir);
-			params->setWorkingDir(dir);
-		}
-	} catch(std::exception e) {
-		::MessageBoxA(NULL, e.what(), "Exception", MB_OK);
-	} catch(...) {
-		::MessageBox(NULL, TEXT("GetSaveFileName crashes!!!"), TEXT(""), MB_OK);
+	fn = ::GetSaveFileName(reinterpret_cast<OPENFILENAME*>(&_ofn))?_fileName:NULL;
+	if (params->getNppGUI()._openSaveDir == dir_last)
+	{
+		::GetCurrentDirectory(MAX_PATH, dir);
+		params->setWorkingDir(dir);
 	}
 
 	::SetCurrentDirectory(dir); 

--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/FileDialog.h
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/FileDialog.h
@@ -36,6 +36,8 @@ using namespace std;
 
 typedef vector<generic_string> stringVector;
 
+
+#include <PshPack1.h>
 struct OPENFILENAMENPP {
    DWORD        lStructSize;
    HWND         hwndOwner;
@@ -61,6 +63,9 @@ struct OPENFILENAMENPP {
    DWORD        dwReserved;
    DWORD        FlagsEx;
 };
+static_assert( __alignof( OPENFILENAMENPP ) == __alignof( OPENFILENAME ), "Incorrect alignment! FileDialog::doOpenSingleFileDlg may cause a crash!" );
+static_assert( sizeof( OPENFILENAMENPP ) == sizeof( OPENFILENAME ), "Differing sizes! FileDialog::doOpenSingleFileDlg may cause a crash!" );
+#include <PopPack.h>
 
 
 generic_string changeExt(generic_string fn, generic_string ext, bool forceReplaced = true);


### PR DESCRIPTION
The only possible way that `GetOpenFileName`/`GetCurrentDirectory` could
generate a `C++` *or* an `SEH` exception is if `_ofn` is misaligned (it was), and
by fixing the alignment, there's no longer reason for a `try`/`catch` block.