### PR TITLE
go to next indicator broken with only one char

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -4118,7 +4118,7 @@ bool Notepad_plus::goToNextIndicator(int indicID2Search, bool isWrap) const
 			posEnd = _pEditView->execute(SCI_INDICATOREND, indicID2Search, 0);
 		}
     }
-    int newPos = posEnd + 1;
+    int newPos = posEnd;
     posStart = _pEditView->execute(SCI_INDICATORSTART, indicID2Search, newPos);
     posEnd = _pEditView->execute(SCI_INDICATOREND, indicID2Search, newPos);
 


### PR DESCRIPTION
go to next indicator (goToNextIndicator) doesn't work when  only one character is selected. It's a classical problem of number of pole and number of interval.
The function go to previous indicatior (goToPreviousIndicator) works fine in those conditions.