### PR TITLE
Fix things related to sort optimization

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -749,7 +749,7 @@ generic_string stringJoin(const std::vector<generic_string>& strings, const gene
 	return joined;
 }
 
-int stoiStrict(const generic_string& input)
+long long stollStrict(const generic_string& input)
 {
 	if (input.empty())
 	{
@@ -774,7 +774,7 @@ int stoiStrict(const generic_string& input)
 			throw std::invalid_argument("Invalid character found.");
 		}
 
-		return std::stoi(input);
+		return std::stoll(input);
 	}
 }
 
@@ -786,7 +786,7 @@ bool allLinesAreNumericOrEmpty(const std::vector<generic_string>& lines)
 		{
 			if (!line.empty())
 			{
-				stoiStrict(line);
+				stollStrict(line);
 			}
 		}
 		catch (std::invalid_argument&)
@@ -833,9 +833,9 @@ std::vector<generic_string> numericSort(std::vector<generic_string> input, bool 
 {
 	// Pre-condition: all strings in "input" are either empty or convertible to int with stoiStrict.
 	// Note that empty lines are filtered out and added back manually to the output at the end.
-	std::vector<int> nonEmptyinputAsInts;
+	std::vector<long long> nonEmptyInputAsNumbers;
 	size_t nofEmptyLines = 0;
-	nonEmptyinputAsInts.reserve(input.size());
+	nonEmptyInputAsNumbers.reserve(input.size());
 	for (const generic_string& line : input)
 	{
 		if (line.empty())
@@ -844,11 +844,11 @@ std::vector<generic_string> numericSort(std::vector<generic_string> input, bool 
 		}
 		else
 		{
-			nonEmptyinputAsInts.push_back(stoiStrict(line));
+			nonEmptyInputAsNumbers.push_back(stollStrict(line));
 		}
 	}
 	assert(nonEmptyinputAsInts.size() + nofEmptyLines == input.size());
-	std::sort(nonEmptyinputAsInts.begin(), nonEmptyinputAsInts.end(), [isDescending](int a, int b)
+	std::sort(nonEmptyInputAsNumbers.begin(), nonEmptyInputAsNumbers.end(), [isDescending](long long a, long long b)
 	{
 		if (isDescending)
 		{
@@ -866,9 +866,9 @@ std::vector<generic_string> numericSort(std::vector<generic_string> input, bool 
 	{
 		output.insert(output.end(), empties.begin(), empties.end());
 	}
-	for (const int& sortedInt : nonEmptyinputAsInts)
+	for (const long long& sortedNumber : nonEmptyInputAsNumbers)
 	{
-		output.push_back(std::to_wstring(sortedInt));
+		output.push_back(std::to_wstring(sortedNumber));
 	}
 	if (isDescending)
 	{

--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -749,11 +749,11 @@ generic_string stringJoin(const std::vector<generic_string> &strings, const gene
 	return joined;
 }
 
-int stoi_CountEmptyLinesAsMinimum(const generic_string &input)
+int stoiStrict(const generic_string &input)
 {
 	if (input.empty())
 	{
-		return INT_MIN;
+		throw std::invalid_argument("Empty input.");
 	}
 	else
 	{
@@ -778,14 +778,14 @@ int stoi_CountEmptyLinesAsMinimum(const generic_string &input)
 	}
 }
 
-bool allLinesAreNumericOrEmpty(const std::vector<generic_string> &lines)
+bool allLinesAreNumeric(const std::vector<generic_string> &lines)
 {
 	const auto endit = lines.end();
 	for (auto it = lines.begin(); it != endit; ++it)
 	{
 		try
 		{
-			stoi_CountEmptyLinesAsMinimum(*it);
+			stoiStrict(*it);
 		}
 		catch (std::invalid_argument&)
 		{
@@ -797,4 +797,50 @@ bool allLinesAreNumericOrEmpty(const std::vector<generic_string> &lines)
 		}
 	}
 	return true;
+}
+
+std::vector<generic_string> lexicographicSort(std::vector<generic_string> input, bool isDescending)
+{
+	std::sort(input.begin(), input.end(), [isDescending](generic_string a, generic_string b)
+	{
+		if (isDescending)
+		{
+			return a.compare(b) > 0;
+		}
+		else
+		{
+			return a.compare(b) < 0;
+		}
+	});
+	return input;
+}
+
+std::vector<generic_string> numericSort(std::vector<generic_string> input, bool isDescending)
+{
+	// Pre-condition: all strings in "input" are convertible to int with stoiStrict.
+	std::vector<int> inputAsInts;
+	std::map<int, generic_string> intToString; // Cache for ints converted to strings.
+	for (auto it = input.begin(); it != input.end(); ++it)
+	{
+		int converted = stoiStrict(*it);
+		inputAsInts.push_back(converted);
+		intToString[converted] = *it;
+	}
+	std::sort(inputAsInts.begin(), inputAsInts.end(), [isDescending](int a, int b)
+	{
+		if (isDescending)
+		{
+			return a > b;
+		}
+		else
+		{
+			return a < b;
+		}
+	});
+	std::vector<generic_string> output;
+	for (auto it = inputAsInts.begin(); it != inputAsInts.end(); ++it)
+	{
+		output.push_back(intToString[*it]);
+	}
+	return output;
 }

--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -780,12 +780,11 @@ int stoiStrict(const generic_string& input)
 
 bool allLinesAreNumeric(const std::vector<generic_string>& lines)
 {
-	const auto endit = lines.end();
-	for (auto it = lines.begin(); it != endit; ++it)
+	for (const generic_string& line : lines)
 	{
 		try
 		{
-			stoiStrict(*it);
+			stoiStrict(line);
 		}
 		catch (std::invalid_argument&)
 		{
@@ -819,9 +818,9 @@ std::vector<generic_string> numericSort(std::vector<generic_string> input, bool 
 {
 	// Pre-condition: all strings in "input" are convertible to int with stoiStrict.
 	std::vector<int> inputAsInts;
-	for (auto it = input.begin(); it != input.end(); ++it)
+	for (const generic_string& line : input)
 	{
-		inputAsInts.push_back(stoiStrict(*it));
+		inputAsInts.push_back(stoiStrict(line));
 	}
 	std::sort(inputAsInts.begin(), inputAsInts.end(), [isDescending](int a, int b)
 	{
@@ -835,9 +834,9 @@ std::vector<generic_string> numericSort(std::vector<generic_string> input, bool 
 		}
 	});
 	std::vector<generic_string> output;
-	for (auto it = inputAsInts.begin(); it != inputAsInts.end(); ++it)
+	for (const int& sortedInt : inputAsInts)
 	{
-		output.push_back(std::to_wstring(*it));
+		output.push_back(std::to_wstring(sortedInt));
 	}
 	return output;
 }

--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -749,9 +749,9 @@ generic_string stringJoin(const std::vector<generic_string> &strings, const gene
 	return joined;
 }
 
-int stoi_CountNewlinesAsMinimum(const generic_string &input, const generic_string &newLine)
+int stoi_CountEmptyLinesAsMinimum(const generic_string &input)
 {
-	if (input.empty() || input == newLine)
+	if (input.empty())
 	{
 		return INT_MIN;
 	}
@@ -759,4 +759,25 @@ int stoi_CountNewlinesAsMinimum(const generic_string &input, const generic_strin
 	{
 		return std::stoi(input);
 	}
+}
+
+bool allLinesAreNumericOrEmpty(const std::vector<generic_string> &lines)
+{
+	const auto endit = lines.end();
+	for (auto it = lines.begin(); it != endit; ++it)
+	{
+		try
+		{
+			stoi_CountEmptyLinesAsMinimum(*it);
+		}
+		catch (std::invalid_argument&)
+		{
+			return false;
+		}
+		catch (std::out_of_range&)
+		{
+			return false;
+		}
+	}
+	return true;
 }

--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -771,7 +771,7 @@ int stoiStrict(const generic_string &input)
 		// Check for other characters which are not allowed.
 		if (input.find_first_not_of(TEXT("-0123456789")) != std::string::npos)
 		{
-			throw new std::invalid_argument("Invalid character found.");
+			throw std::invalid_argument("Invalid character found.");
 		}
 
 		return std::stoi(input);

--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -748,3 +748,15 @@ generic_string stringJoin(const std::vector<generic_string> &strings, const gene
 	}
 	return joined;
 }
+
+int stoi_CountNewlinesAsMinimum(const generic_string &input, const generic_string &newLine)
+{
+	if (input.empty() || input == newLine)
+	{
+		return INT_MIN;
+	}
+	else
+	{
+		return std::stoi(input);
+	}
+}

--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -818,6 +818,7 @@ std::vector<generic_string> numericSort(std::vector<generic_string> input, bool 
 {
 	// Pre-condition: all strings in "input" are convertible to int with stoiStrict.
 	std::vector<int> inputAsInts;
+	inputAsInts.reserve(input.size());
 	for (const generic_string& line : input)
 	{
 		inputAsInts.push_back(stoiStrict(line));
@@ -834,6 +835,7 @@ std::vector<generic_string> numericSort(std::vector<generic_string> input, bool 
 		}
 	});
 	std::vector<generic_string> output;
+	output.reserve(input.size());
 	for (const int& sortedInt : inputAsInts)
 	{
 		output.push_back(std::to_wstring(sortedInt));

--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -718,7 +718,7 @@ generic_string stringReplace(generic_string subject, const generic_string& searc
 	return subject;
 }
 
-std::vector<generic_string> stringSplit(const generic_string& input, generic_string delimiter)
+std::vector<generic_string> stringSplit(const generic_string& input, const generic_string &delimiter)
 {
 	auto start = 0U;
 	auto end = input.find(delimiter);
@@ -734,7 +734,7 @@ std::vector<generic_string> stringSplit(const generic_string& input, generic_str
 	return output;
 }
 
-generic_string stringJoin(const std::vector<generic_string> &strings, generic_string separator)
+generic_string stringJoin(const std::vector<generic_string> &strings, const generic_string &separator)
 {
 	generic_string joined;
 	size_t length = strings.size();

--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -718,7 +718,7 @@ generic_string stringReplace(generic_string subject, const generic_string& searc
 	return subject;
 }
 
-std::vector<generic_string> stringSplit(const generic_string& input, const generic_string &delimiter)
+std::vector<generic_string> stringSplit(const generic_string& input, const generic_string& delimiter)
 {
 	auto start = 0U;
 	auto end = input.find(delimiter);
@@ -734,7 +734,7 @@ std::vector<generic_string> stringSplit(const generic_string& input, const gener
 	return output;
 }
 
-generic_string stringJoin(const std::vector<generic_string> &strings, const generic_string &separator)
+generic_string stringJoin(const std::vector<generic_string>& strings, const generic_string& separator)
 {
 	generic_string joined;
 	size_t length = strings.size();
@@ -749,7 +749,7 @@ generic_string stringJoin(const std::vector<generic_string> &strings, const gene
 	return joined;
 }
 
-int stoiStrict(const generic_string &input)
+int stoiStrict(const generic_string& input)
 {
 	if (input.empty())
 	{
@@ -778,7 +778,7 @@ int stoiStrict(const generic_string &input)
 	}
 }
 
-bool allLinesAreNumeric(const std::vector<generic_string> &lines)
+bool allLinesAreNumeric(const std::vector<generic_string>& lines)
 {
 	const auto endit = lines.end();
 	for (auto it = lines.begin(); it != endit; ++it)

--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -757,6 +757,23 @@ int stoi_CountEmptyLinesAsMinimum(const generic_string &input)
 	}
 	else
 	{
+		// Check minus characters.
+		const int minuses = std::count(input.begin(), input.end(), TEXT('-'));
+		if (minuses > 1)
+		{
+			throw std::invalid_argument("More than one minus sign.");
+		}
+		else if (minuses == 1 && input[0] != TEXT('-'))
+		{
+			throw std::invalid_argument("Minus sign must be first.");
+		}
+
+		// Check for other characters which are not allowed.
+		if (input.find_first_not_of(TEXT("-0123456789")) != std::string::npos)
+		{
+			throw new std::invalid_argument("Invalid character found.");
+		}
+
 		return std::stoi(input);
 	}
 }

--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -778,13 +778,16 @@ int stoiStrict(const generic_string& input)
 	}
 }
 
-bool allLinesAreNumeric(const std::vector<generic_string>& lines)
+bool allLinesAreNumericOrEmpty(const std::vector<generic_string>& lines)
 {
 	for (const generic_string& line : lines)
 	{
 		try
 		{
-			stoiStrict(line);
+			if (!line.empty())
+			{
+				stoiStrict(line);
+			}
 		}
 		catch (std::invalid_argument&)
 		{
@@ -796,6 +799,18 @@ bool allLinesAreNumeric(const std::vector<generic_string>& lines)
 		}
 	}
 	return true;
+}
+
+std::vector<generic_string> repeatString(const generic_string& text, const size_t count)
+{
+	std::vector<generic_string> output;
+	output.reserve(count);
+	for (size_t i = 0; i < count; ++i)
+	{
+		output.push_back(text);
+	}
+	assert(output.size() == count);
+	return output;
 }
 
 std::vector<generic_string> lexicographicSort(std::vector<generic_string> input, bool isDescending)
@@ -816,14 +831,24 @@ std::vector<generic_string> lexicographicSort(std::vector<generic_string> input,
 
 std::vector<generic_string> numericSort(std::vector<generic_string> input, bool isDescending)
 {
-	// Pre-condition: all strings in "input" are convertible to int with stoiStrict.
-	std::vector<int> inputAsInts;
-	inputAsInts.reserve(input.size());
+	// Pre-condition: all strings in "input" are either empty or convertible to int with stoiStrict.
+	// Note that empty lines are filtered out and added back manually to the output at the end.
+	std::vector<int> nonEmptyinputAsInts;
+	size_t nofEmptyLines = 0;
+	nonEmptyinputAsInts.reserve(input.size());
 	for (const generic_string& line : input)
 	{
-		inputAsInts.push_back(stoiStrict(line));
+		if (line.empty())
+		{
+			++nofEmptyLines;
+		}
+		else
+		{
+			nonEmptyinputAsInts.push_back(stoiStrict(line));
+		}
 	}
-	std::sort(inputAsInts.begin(), inputAsInts.end(), [isDescending](int a, int b)
+	assert(nonEmptyinputAsInts.size() + nofEmptyLines == input.size());
+	std::sort(nonEmptyinputAsInts.begin(), nonEmptyinputAsInts.end(), [isDescending](int a, int b)
 	{
 		if (isDescending)
 		{
@@ -836,9 +861,19 @@ std::vector<generic_string> numericSort(std::vector<generic_string> input, bool 
 	});
 	std::vector<generic_string> output;
 	output.reserve(input.size());
-	for (const int& sortedInt : inputAsInts)
+	const std::vector<generic_string> empties = repeatString(TEXT(""), nofEmptyLines);
+	if (!isDescending)
+	{
+		output.insert(output.end(), empties.begin(), empties.end());
+	}
+	for (const int& sortedInt : nonEmptyinputAsInts)
 	{
 		output.push_back(std::to_wstring(sortedInt));
 	}
+	if (isDescending)
+	{
+		output.insert(output.end(), empties.begin(), empties.end());
+	}
+	assert(output.size() == input.size());
 	return output;
 }

--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -819,12 +819,9 @@ std::vector<generic_string> numericSort(std::vector<generic_string> input, bool 
 {
 	// Pre-condition: all strings in "input" are convertible to int with stoiStrict.
 	std::vector<int> inputAsInts;
-	std::map<int, generic_string> intToString; // Cache for ints converted to strings.
 	for (auto it = input.begin(); it != input.end(); ++it)
 	{
-		int converted = stoiStrict(*it);
-		inputAsInts.push_back(converted);
-		intToString[converted] = *it;
+		inputAsInts.push_back(stoiStrict(*it));
 	}
 	std::sort(inputAsInts.begin(), inputAsInts.end(), [isDescending](int a, int b)
 	{
@@ -840,7 +837,7 @@ std::vector<generic_string> numericSort(std::vector<generic_string> input, bool 
 	std::vector<generic_string> output;
 	for (auto it = inputAsInts.begin(); it != inputAsInts.end(); ++it)
 	{
-		output.push_back(intToString[*it]);
+		output.push_back(std::to_wstring(*it));
 	}
 	return output;
 }

--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -190,7 +190,10 @@ generic_string stringToUpper(generic_string strToConvert);
 generic_string stringReplace(generic_string subject, const generic_string& search, const generic_string& replace);
 std::vector<generic_string> stringSplit(const generic_string& input, const generic_string &delimiter);
 generic_string stringJoin(const std::vector<generic_string> &strings, const generic_string &separator);
-int stoi_CountEmptyLinesAsMinimum(const generic_string &input);
-bool allLinesAreNumericOrEmpty(const std::vector<generic_string> &lines);
+int stoiStrict(const generic_string &input);
+bool allLinesAreNumeric(const std::vector<generic_string> &lines);
+
+std::vector<generic_string> numericSort(std::vector<generic_string> input, bool isDescending);
+std::vector<generic_string> lexicographicSort(std::vector<generic_string> input, bool isDescending);
 
 #endif //M30_IDE_COMMUN_H

--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -188,10 +188,10 @@ generic_string PathAppend(generic_string &strDest, const generic_string & str2ap
 COLORREF getCtrlBgColor(HWND hWnd);
 generic_string stringToUpper(generic_string strToConvert);
 generic_string stringReplace(generic_string subject, const generic_string& search, const generic_string& replace);
-std::vector<generic_string> stringSplit(const generic_string& input, const generic_string &delimiter);
-generic_string stringJoin(const std::vector<generic_string> &strings, const generic_string &separator);
-int stoiStrict(const generic_string &input);
-bool allLinesAreNumeric(const std::vector<generic_string> &lines);
+std::vector<generic_string> stringSplit(const generic_string& input, const generic_string& delimiter);
+generic_string stringJoin(const std::vector<generic_string>& strings, const generic_string& separator);
+int stoiStrict(const generic_string& input);
+bool allLinesAreNumeric(const std::vector<generic_string>& lines);
 
 std::vector<generic_string> numericSort(std::vector<generic_string> input, bool isDescending);
 std::vector<generic_string> lexicographicSort(std::vector<generic_string> input, bool isDescending);

--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -190,7 +190,7 @@ generic_string stringToUpper(generic_string strToConvert);
 generic_string stringReplace(generic_string subject, const generic_string& search, const generic_string& replace);
 std::vector<generic_string> stringSplit(const generic_string& input, const generic_string& delimiter);
 generic_string stringJoin(const std::vector<generic_string>& strings, const generic_string& separator);
-int stoiStrict(const generic_string& input);
+long long stollStrict(const generic_string& input);
 bool allLinesAreNumericOrEmpty(const std::vector<generic_string>& lines);
 std::vector<generic_string> repeatString(const generic_string& text, const size_t count);
 

--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -190,6 +190,7 @@ generic_string stringToUpper(generic_string strToConvert);
 generic_string stringReplace(generic_string subject, const generic_string& search, const generic_string& replace);
 std::vector<generic_string> stringSplit(const generic_string& input, const generic_string &delimiter);
 generic_string stringJoin(const std::vector<generic_string> &strings, const generic_string &separator);
-int stoi_CountNewlinesAsMinimum(const generic_string &input, const generic_string &newLine);
+int stoi_CountEmptyLinesAsMinimum(const generic_string &input);
+bool allLinesAreNumericOrEmpty(const std::vector<generic_string> &lines);
 
 #endif //M30_IDE_COMMUN_H

--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -188,7 +188,7 @@ generic_string PathAppend(generic_string &strDest, const generic_string & str2ap
 COLORREF getCtrlBgColor(HWND hWnd);
 generic_string stringToUpper(generic_string strToConvert);
 generic_string stringReplace(generic_string subject, const generic_string& search, const generic_string& replace);
-std::vector<generic_string> stringSplit(const generic_string& input, generic_string delimiter);
-generic_string stringJoin(const std::vector<generic_string> &strings, generic_string separator);
+std::vector<generic_string> stringSplit(const generic_string& input, const generic_string &delimiter);
+generic_string stringJoin(const std::vector<generic_string> &strings, const generic_string &separator);
 
 #endif //M30_IDE_COMMUN_H

--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -190,5 +190,6 @@ generic_string stringToUpper(generic_string strToConvert);
 generic_string stringReplace(generic_string subject, const generic_string& search, const generic_string& replace);
 std::vector<generic_string> stringSplit(const generic_string& input, const generic_string &delimiter);
 generic_string stringJoin(const std::vector<generic_string> &strings, const generic_string &separator);
+int stoi_CountNewlinesAsMinimum(const generic_string &input, const generic_string &newLine);
 
 #endif //M30_IDE_COMMUN_H

--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -191,7 +191,8 @@ generic_string stringReplace(generic_string subject, const generic_string& searc
 std::vector<generic_string> stringSplit(const generic_string& input, const generic_string& delimiter);
 generic_string stringJoin(const std::vector<generic_string>& strings, const generic_string& separator);
 int stoiStrict(const generic_string& input);
-bool allLinesAreNumeric(const std::vector<generic_string>& lines);
+bool allLinesAreNumericOrEmpty(const std::vector<generic_string>& lines);
+std::vector<generic_string> repeatString(const generic_string& text, const size_t count);
 
 std::vector<generic_string> numericSort(std::vector<generic_string> input, bool isDescending);
 std::vector<generic_string> lexicographicSort(std::vector<generic_string> input, bool isDescending);

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -375,7 +375,7 @@ void Notepad_plus::command(int id)
 			}
 
 			_pEditView->execute(SCI_BEGINUNDOACTION);
-			_pEditView->quickSortLines(fromLine, toLine, id == IDM_EDIT_SORTLINES_DESCENDING);
+			_pEditView->sortLines(fromLine, toLine, id == IDM_EDIT_SORTLINES_DESCENDING);
 			_pEditView->execute(SCI_ENDUNDOACTION);
 
 			if (hasSelection) // there was 1 selection, so we restore it

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -2958,6 +2958,16 @@ void ScintillaEditView::sortLines(size_t fromLine, size_t toLine, bool isDescend
 	const int endPos = execute(SCI_POSITIONFROMLINE, toLine) + execute(SCI_LINELENGTH, toLine);
 	const generic_string text = getGenericTextAsString(startPos, endPos);
 	std::vector<generic_string> splitText = stringSplit(text, getEOLString());
+	const size_t lineCount = execute(SCI_GETLINECOUNT);
+	const bool sortAllLines = toLine == lineCount - 1;
+	if (!sortAllLines)
+	{
+		if (splitText.rbegin()->empty())
+		{
+			splitText.pop_back();
+		}
+	}
+	assert(toLine - fromLine + 1 == splitText.size());
 	std::sort(splitText.begin(), splitText.end(), [isDescending](generic_string a, generic_string b)
 	{
 		if (isDescending)
@@ -2970,7 +2980,14 @@ void ScintillaEditView::sortLines(size_t fromLine, size_t toLine, bool isDescend
 		}
 	});
 	const generic_string joined = stringJoin(splitText, getEOLString());
-	replaceTarget(joined.c_str(), startPos, endPos);
+	if (sortAllLines)
+	{
+		replaceTarget(joined.c_str(), startPos, endPos);
+	}
+	else
+	{
+		replaceTarget((joined + getEOLString()).c_str(), startPos, endPos);
+	}
 }
 
 bool ScintillaEditView::isTextDirectionRTL() const

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -2947,7 +2947,7 @@ void ScintillaEditView::insertNewLineBelowCurrentLine()
 	execute(SCI_SETEMPTYSELECTION, execute(SCI_POSITIONFROMLINE, current_line + 1));
 }
 
-void ScintillaEditView::quickSortLines(size_t fromLine, size_t toLine, bool isDescending)
+void ScintillaEditView::sortLines(size_t fromLine, size_t toLine, bool isDescending)
 {
 	if (fromLine >= toLine)
 	{

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -1703,7 +1703,7 @@ generic_string ScintillaEditView::getGenericTextAsString(int start, int end) con
 {
 	assert(end > start);
 	const int bufSize = end - start + 1;
-	_TCHAR *buf = new _TCHAR[bufSize];
+	TCHAR *buf = new TCHAR[bufSize];
 	getGenericText(buf, bufSize, start, end);
 	generic_string text = buf;
 	delete[] buf;

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -2979,37 +2979,17 @@ void ScintillaEditView::sortLines(size_t fromLine, size_t toLine, bool isDescend
 		}
 	}
 	assert(toLine - fromLine + 1 == splitText.size());
-	const bool isNumericSort = allLinesAreNumericOrEmpty(splitText);
-	std::sort(splitText.begin(), splitText.end(), [isDescending, isNumericSort](generic_string a, generic_string b)
+	const bool isNumericSort = allLinesAreNumeric(splitText);
+	std::vector<generic_string> sortedText;
+	if (isNumericSort)
 	{
-		if (isDescending)
-		{
-			if (isNumericSort)
-			{
-				int numA = stoi_CountEmptyLinesAsMinimum(a);
-				int numB = stoi_CountEmptyLinesAsMinimum(b);
-				return numA > numB;
-			}
-			else
-			{
-				return a.compare(b) > 0;
-			}
-		}
-		else
-		{
-			if (isNumericSort)
-			{
-				int numA = stoi_CountEmptyLinesAsMinimum(a);
-				int numB = stoi_CountEmptyLinesAsMinimum(b);
-				return numA < numB;
-			}
-			else
-			{
-				return a.compare(b) < 0;
-			}
-		}
-	});
-	const generic_string joined = stringJoin(splitText, getEOLString());
+		sortedText = numericSort(splitText, isDescending);
+	}
+	else
+	{
+		sortedText = lexicographicSort(splitText, isDescending);
+	}
+	const generic_string joined = stringJoin(sortedText, getEOLString());
 	if (sortAllLines)
 	{
 		replaceTarget(joined.c_str(), startPos, endPos);

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -2958,27 +2958,6 @@ void ScintillaEditView::insertNewLineBelowCurrentLine()
 	execute(SCI_SETEMPTYSELECTION, execute(SCI_POSITIONFROMLINE, current_line + 1));
 }
 
-bool ScintillaEditView::allLinesAreNumeric(size_t fromLine, size_t toLine)
-{
-	const generic_string newLine = getEOLString();
-	for (size_t i = fromLine; i <= toLine; ++i)
-	{
-		try
-		{
-			stoi_CountNewlinesAsMinimum(getLine(i), newLine);
-		}
-		catch (std::invalid_argument&)
-		{
-			return false;
-		}
-		catch (std::out_of_range&)
-		{
-			return false;
-		}
-	}
-	return true;
-}
-
 void ScintillaEditView::sortLines(size_t fromLine, size_t toLine, bool isDescending)
 {
 	if (fromLine >= toLine)
@@ -3000,16 +2979,15 @@ void ScintillaEditView::sortLines(size_t fromLine, size_t toLine, bool isDescend
 		}
 	}
 	assert(toLine - fromLine + 1 == splitText.size());
-	const bool isNumericSort = allLinesAreNumeric(fromLine, toLine);
-	const generic_string newLine = getEOLString();
-	std::sort(splitText.begin(), splitText.end(), [isDescending, isNumericSort, newLine](generic_string a, generic_string b)
+	const bool isNumericSort = allLinesAreNumericOrEmpty(splitText);
+	std::sort(splitText.begin(), splitText.end(), [isDescending, isNumericSort](generic_string a, generic_string b)
 	{
 		if (isDescending)
 		{
 			if (isNumericSort)
 			{
-				int numA = stoi_CountNewlinesAsMinimum(a, newLine);
-				int numB = stoi_CountNewlinesAsMinimum(b, newLine);
+				int numA = stoi_CountEmptyLinesAsMinimum(a);
+				int numB = stoi_CountEmptyLinesAsMinimum(b);
 				return numA > numB;
 			}
 			else
@@ -3021,8 +2999,8 @@ void ScintillaEditView::sortLines(size_t fromLine, size_t toLine, bool isDescend
 		{
 			if (isNumericSort)
 			{
-				int numA = stoi_CountNewlinesAsMinimum(a, newLine);
-				int numB = stoi_CountNewlinesAsMinimum(b, newLine);
+				int numA = stoi_CountEmptyLinesAsMinimum(a);
+				int numB = stoi_CountEmptyLinesAsMinimum(b);
 				return numA < numB;
 			}
 			else

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -1922,17 +1922,6 @@ void ScintillaEditView::getLine(int lineNumber, TCHAR * line, int lineBufferLen)
 	delete [] lineA;
 }
 
-generic_string ScintillaEditView::getLine(int lineNumber)
-{
-	int lineLen = execute(SCI_LINELENGTH, lineNumber);
-	const int bufSize = 1 + lineLen;
-	_TCHAR *buf = new _TCHAR[bufSize];
-	getLine(lineNumber, buf, bufSize);
-	generic_string text = buf;
-	delete[] buf;
-	return text;
-}
-
 void ScintillaEditView::addText(int length, const char *buf)
 {
 	execute(SCI_ADDTEXT, length, (LPARAM)buf);

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -2970,8 +2970,8 @@ void ScintillaEditView::sortLines(size_t fromLine, size_t toLine, bool isDescend
 	const generic_string text = getGenericTextAsString(startPos, endPos);
 	std::vector<generic_string> splitText = stringSplit(text, getEOLString());
 	const size_t lineCount = execute(SCI_GETLINECOUNT);
-	const bool sortAllLines = toLine == lineCount - 1;
-	if (!sortAllLines)
+	const bool sortEntireDocument = toLine == lineCount - 1;
+	if (!sortEntireDocument)
 	{
 		if (splitText.rbegin()->empty())
 		{
@@ -2990,7 +2990,7 @@ void ScintillaEditView::sortLines(size_t fromLine, size_t toLine, bool isDescend
 		sortedText = lexicographicSort(splitText, isDescending);
 	}
 	const generic_string joined = stringJoin(sortedText, getEOLString());
-	if (sortAllLines)
+	if (sortEntireDocument)
 	{
 		replaceTarget(joined.c_str(), startPos, endPos);
 	}

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -2968,7 +2968,7 @@ void ScintillaEditView::sortLines(size_t fromLine, size_t toLine, bool isDescend
 		}
 	}
 	assert(toLine - fromLine + 1 == splitText.size());
-	const bool isNumericSort = allLinesAreNumeric(splitText);
+	const bool isNumericSort = allLinesAreNumericOrEmpty(splitText);
 	std::vector<generic_string> sortedText;
 	if (isNumericSort)
 	{

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
@@ -271,6 +271,7 @@ public:
 	void showAutoComletion(int lenEntered, const TCHAR * list);
 	void showCallTip(int startPos, const TCHAR * def);
 	void getLine(int lineNumber, TCHAR * line, int lineBufferLen);
+	generic_string getLine(int lineNumber);
 	void addText(int length, const char *buf);
 
 	void insertNewLineAboveCurrentLine();
@@ -637,6 +638,7 @@ public:
 	void scrollPosToCenter(int pos);
 	generic_string getEOLString();
 	void sortLines(size_t fromLine, size_t toLine, bool isDescending);
+	bool allLinesAreNumeric(size_t fromLine, size_t toLine);
 	void changeTextDirection(bool isRTL);
 	bool isTextDirectionRTL() const;
 

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
@@ -638,7 +638,6 @@ public:
 	void scrollPosToCenter(int pos);
 	generic_string getEOLString();
 	void sortLines(size_t fromLine, size_t toLine, bool isDescending);
-	bool allLinesAreNumeric(size_t fromLine, size_t toLine);
 	void changeTextDirection(bool isRTL);
 	bool isTextDirectionRTL() const;
 

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
@@ -636,7 +636,7 @@ public:
 	};
 	void scrollPosToCenter(int pos);
 	generic_string getEOLString();
-	void quickSortLines(size_t fromLine, size_t toLine, bool isDescending);
+	void sortLines(size_t fromLine, size_t toLine, bool isDescending);
 	void changeTextDirection(bool isRTL);
 	bool isTextDirectionRTL() const;
 

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
@@ -271,7 +271,6 @@ public:
 	void showAutoComletion(int lenEntered, const TCHAR * list);
 	void showCallTip(int startPos, const TCHAR * def);
 	void getLine(int lineNumber, TCHAR * line, int lineBufferLen);
-	generic_string getLine(int lineNumber);
 	void addText(int length, const char *buf);
 
 	void insertNewLineAboveCurrentLine();


### PR DESCRIPTION
Some more fixes for yesterday's sort optimization PR.

Most commits should be self-explanatory.

6e84be2 fixes a bug where the sort would insert newline at the wrong place unless the entire file was sorted. To test, create a file like this:

```
1
2

3
```

Select the first two lines and sort in ascending fashion. Using yesterday's code, the file would end up like this (note that first line is an empty line):

```

1
2
3
```

But obviously 1-2 is already in ascending order and the file should have been left untouched.