### PR TITLE
In debug build, don't treat warnings as errors

### DIFF
--- a/PowerEditor/visual.net/notepadPlus.vcxproj
+++ b/PowerEditor/visual.net/notepadPlus.vcxproj
@@ -67,7 +67,7 @@
       <PrecompiledHeaderFile>precompiledHeaders.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
       <WarningLevel>Level4</WarningLevel>
-      <TreatWarningAsError>true</TreatWarningAsError>
+      <TreatWarningAsError>false</TreatWarningAsError>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>


### PR DESCRIPTION
See title.

I find this setting to be more of an impediment than a help in debug builds (mainly due to the "unused variables" warning which crops up if you comment something out).