### PR TITLE
Fix file status auto-detection settings

### DIFF
--- a/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
+++ b/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
@@ -906,11 +906,6 @@ BOOL CALLBACK SettingsDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM)
 				case IDC_CHECK_FILEAUTODETECTION:
 				{
 					bool isChecked = isCheckedOrNot(IDC_CHECK_FILEAUTODETECTION);
-					if (!isChecked)
-					{
-						::SendDlgItemMessage(_hSelf, IDC_CHECK_UPDATESILENTLY, BM_SETCHECK, BST_UNCHECKED, 0);
-						::SendDlgItemMessage(_hSelf, IDC_CHECK_UPDATEGOTOEOF, BM_SETCHECK, BST_UNCHECKED, 0);
-					}
 					::EnableWindow(::GetDlgItem(_hSelf, IDC_CHECK_UPDATESILENTLY), isChecked);
 					::EnableWindow(::GetDlgItem(_hSelf, IDC_CHECK_UPDATEGOTOEOF), isChecked);
 

--- a/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
+++ b/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
@@ -914,7 +914,23 @@ BOOL CALLBACK SettingsDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM)
 					::EnableWindow(::GetDlgItem(_hSelf, IDC_CHECK_UPDATESILENTLY), isChecked);
 					::EnableWindow(::GetDlgItem(_hSelf, IDC_CHECK_UPDATEGOTOEOF), isChecked);
 
-					nppGUI._fileAutoDetection = isChecked?cdAutoUpdate:cdDisabled;
+					bool isSilent = isCheckedOrNot(IDC_CHECK_UPDATESILENTLY);
+					bool isGo2End = isCheckedOrNot(IDC_CHECK_UPDATEGOTOEOF);
+
+					ChangeDetect cd;
+
+					if (!isChecked)
+						cd = cdDisabled;
+					else if (!isSilent && !isGo2End)
+						cd = cdEnabled;
+					else if (!isSilent && isGo2End)
+						cd = cdGo2end;
+					else if (isSilent && !isGo2End)
+						cd = cdAutoUpdate;
+					else //(isSilent && isGo2End)
+						cd = cdAutoUpdateGo2end;
+
+					nppGUI._fileAutoDetection = cd;
 				}
 				return TRUE;
 


### PR DESCRIPTION
This patch fixes an issue with the file status auto-detection settings.

If you uncheck and then check the "Enable" check box under "File Status Auto-Detection" in preferences, "Update silently" is displayed unchecked, but files are actually updated silently.

This patch also makes the "Update silently" and "Scroll to the last line" values retained when you disable/enable status auto-detection.

http://sourceforge.net/p/notepad-plus/patches/661/