### PR TITLE
shortcut.xml file saved on modification with comments

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -3941,7 +3941,8 @@ bool Notepad_plus::saveScintillaParams()
 
 bool Notepad_plus::addCurrentMacro()
 {
-	vector<MacroShortcut> & theMacros = (NppParameters::getInstance())->getMacroList();
+	NppParameters * pNppParam = NppParameters::getInstance();
+	vector<MacroShortcut> & theMacros = pNppParam->getMacroList();
 
 	int nbMacro = theMacros.size();
 
@@ -3960,16 +3961,17 @@ bool Notepad_plus::addCurrentMacro()
             // Insert the separator and modify/delete command
 			::InsertMenu(hMacroMenu, posBase + nbMacro + 1, MF_BYPOSITION, (unsigned int)-1, 0);
 
-			NativeLangSpeaker *pNativeLangSpeaker = (NppParameters::getInstance())->getNativeLangSpeaker();
+			NativeLangSpeaker *pNativeLangSpeaker = pNppParam->getNativeLangSpeaker();
 			generic_string nativeLangShortcutMapperMacro = pNativeLangSpeaker->getNativeLangMenuString(IDM_SETTING_SHORTCUT_MAPPER_MACRO);
 			if (nativeLangShortcutMapperMacro == TEXT(""))
 				nativeLangShortcutMapperMacro = TEXT("Modify Shortcut/Delete Macro...");
 
 			::InsertMenu(hMacroMenu, posBase + nbMacro + 2, MF_BYCOMMAND, IDM_SETTING_SHORTCUT_MAPPER_MACRO, nativeLangShortcutMapperMacro.c_str());
-        }
+		}
 		theMacros.push_back(ms);
 		::InsertMenu(hMacroMenu, posBase + nbMacro, MF_BYPOSITION, cmdID, ms.toMenuItemString().c_str());
 		_accelerator.updateShortcuts();
+		pNppParam->writeShortcuts();
 		return true;
 	}
 	return false;

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -1555,11 +1555,6 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lPa
 			    saveUserDefineLangs();
 				
 				//
-				// saving shortcuts.xml
-				//
-			    saveShortcuts();
-
-				//
 				// saving session.xml
 				//
 			    if (nppgui._rememberLastSession && !nppgui._isCmdlineNosessionActivated)

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -2803,6 +2803,15 @@ void NppParameters::writeUserDefinedLang()
 
 void NppParameters::insertCmd(TiXmlNode *shortcutsRoot, const CommandShortcut & cmd)
 {
+	//insert a comment about which command is written in the XML file
+	TiXmlNode *sc2 = shortcutsRoot->InsertEndChild(TiXmlComment());
+	generic_string str = TEXT("");
+
+	str.append(cmd.getName());
+	str.append(TEXT(" - "));
+	str.append(cmd.toString());
+	sc2->ToComment()->SetValue( str );
+
 	const KeyCombo & key = cmd.getKeyCombo();
 	TiXmlNode *sc = shortcutsRoot->InsertEndChild(TiXmlElement(TEXT("Shortcut")));
 	sc->ToElement()->SetAttribute(TEXT("id"), cmd.getID());
@@ -2847,6 +2856,15 @@ void NppParameters::insertUserCmd(TiXmlNode *userCmdRoot, const UserCommand & us
 
 void NppParameters::insertPluginCmd(TiXmlNode *pluginCmdRoot, const PluginCmdShortcut & pluginCmd)
 {
+	//insert a comment about which command is written in the XML file
+	TiXmlNode *sc2 = pluginCmdRoot->InsertEndChild(TiXmlComment());
+	generic_string str = TEXT("");
+
+	str.append(TEXT("moduleName="));
+	str.append(pluginCmd.getModuleName());
+	str.append(TEXT(" command="));
+	str.append(pluginCmd.getName());
+	sc2->ToComment()->SetValue( str ) ;
 	const KeyCombo & key = pluginCmd.getKeyCombo();
 	TiXmlNode *pluginCmdNode = pluginCmdRoot->InsertEndChild(TiXmlElement(TEXT("PluginCommand")));
 	pluginCmdNode->ToElement()->SetAttribute(TEXT("moduleName"), pluginCmd.getModuleName());
@@ -2859,6 +2877,18 @@ void NppParameters::insertPluginCmd(TiXmlNode *pluginCmdRoot, const PluginCmdSho
 
 void NppParameters::insertScintKey(TiXmlNode *scintKeyRoot, const ScintillaKeyMap & scintKeyMap)
 {
+	TiXmlNode * keyComment;
+	keyComment = scintKeyRoot->InsertEndChild(TiXmlComment());
+
+	generic_string strMenuName = TEXT("");
+	strMenuName.append(scintKeyMap.getMenuName());
+	strMenuName.append(TEXT(" - "));
+
+	generic_string str = TEXT("");
+	str.append(strMenuName);
+	str.append(scintKeyMap.toString());
+	keyComment->ToComment()->SetValue(str);
+
 	TiXmlNode *keyRoot = scintKeyRoot->InsertEndChild(TiXmlElement(TEXT("ScintKey")));
 	keyRoot->ToElement()->SetAttribute(TEXT("ScintID"), scintKeyMap.getScintillaKeyID());
 	keyRoot->ToElement()->SetAttribute(TEXT("menuCmdID"), scintKeyMap.getMenuCmdID());
@@ -2873,8 +2903,17 @@ void NppParameters::insertScintKey(TiXmlNode *scintKeyRoot, const ScintillaKeyMa
 	//Add additional shortcuts
 	size_t size = scintKeyMap.getSize();
 	if (size > 1) {
+		TiXmlNode * keyNextComment;
 		TiXmlNode * keyNext;
 		for(size_t i = 1; i < size; ++i) {
+			keyNextComment = keyRoot->InsertEndChild(TiXmlComment());
+
+			generic_string str = TEXT("");
+			str.append(strMenuName);
+			str.append(scintKeyMap.toString());
+
+			keyNextComment->ToComment()->SetValue(str);
+
 			keyNext = keyRoot->InsertEndChild(TiXmlElement(TEXT("NextKey")));
 			key = scintKeyMap.getKeyComboByIndex(i);
 			keyNext->ToElement()->SetAttribute(TEXT("Ctrl"), key._isCtrl?TEXT("yes"):TEXT("no"));

--- a/PowerEditor/src/WinControls/Grid/ShortcutMapper.cpp
+++ b/PowerEditor/src/WinControls/Grid/ShortcutMapper.cpp
@@ -242,7 +242,8 @@ BOOL CALLBACK ShortcutMapper::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 								_babygrid.setText(row, 2, csc.toString().c_str());
 								//Notify current Accelerator class to update everything
 								nppParam->getAccelerator()->updateShortcuts();
-								
+								nppParam->writeShortcuts();
+
 							}
 							break; }
 						case STATE_MACRO: {
@@ -257,7 +258,8 @@ BOOL CALLBACK ShortcutMapper::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 
 								//Notify current Accelerator class to update everything
 								nppParam->getAccelerator()->updateShortcuts();
-								
+								nppParam->writeShortcuts();
+
 							}
 							break; }
 						case STATE_USER: {
@@ -273,7 +275,8 @@ BOOL CALLBACK ShortcutMapper::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 
 								//Notify current Accelerator class to update everything
 								nppParam->getAccelerator()->updateShortcuts();
-								
+								nppParam->writeShortcuts();
+
 							}
 							break; }
 						case STATE_PLUGIN: {
@@ -289,6 +292,7 @@ BOOL CALLBACK ShortcutMapper::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 
 								//Notify current Accelerator class to update everything
 								nppParam->getAccelerator()->updateShortcuts();
+								nppParam->writeShortcuts();
 								unsigned long cmdID = pcsc.getID();
 								ShortcutKey shortcut;
 								shortcut._isAlt = pcsc.getKeyCombo()._isAlt;
@@ -313,6 +317,7 @@ BOOL CALLBACK ShortcutMapper::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 
 								//Notify current Accelerator class to update key
 								nppParam->getScintillaAccelerator()->updateKeys();
+								nppParam->writeShortcuts();
 							}
 							break; 
 						}
@@ -387,6 +392,7 @@ BOOL CALLBACK ShortcutMapper::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 
                         // updateShortcuts() will update all menu item - the menu items will be shifted
 						nppParam->getAccelerator()->updateShortcuts();
+						nppParam->writeShortcuts();
 
                         // All menu items are shifted up. So we delete the last item
                         ::RemoveMenu(hMenu, posBase + nbElem, MF_BYPOSITION);


### PR DESCRIPTION
shortcut.xml file isn't saved on exit but on shortcut modification or macro modification.

Now, it's possible to edit in notepad++ the file shortcut.xml then restart notepad++ (same procedure as contextMenu.xml file) 

shortcut.xml file also contains a description of each shortcut . Example : 

```xml
<NotepadPlus>
    <InternalCommands>
        <!--Appliquer le style 1 - Ctrl+1-->
        <Shortcut id="43022" Ctrl="yes" Alt="no" Shift="no" Key="49" />
        <!--Appliquer le style 2 - Ctrl+2-->
        <Shortcut id="43024" Ctrl="yes" Alt="no" Shift="no" Key="50" />
        <!--Appliquer le style 3 - Ctrl+3-->
        <Shortcut id="43026" Ctrl="yes" Alt="no" Shift="no" Key="51" />
        <!--Nouveau - Ctrl+N-->
        <Shortcut id="41001" Ctrl="yes" Alt="no" Shift="no" Key="78" />
    </InternalCommands>
    <Macros>
        <Macro name="Trim Trailing and save" Ctrl="yes" Alt="no" Shift="no" Key="83"> 
            <Action type="2" message="0" wParam="42024" lParam="0" sParam="" />
            <Action type="2" message="0" wParam="41006" lParam="0" sParam="" />
        </Macro>
    </Macros>
    <UserDefinedCommands />
    <PluginCommands>
        <!--moduleName=CodeAlignmentNpp.dll command=Align by...-->
        <PluginCommand moduleName="CodeAlignmentNpp.dll" internalID="0" Ctrl="yes" Alt="yes" Shift="yes" Key="187" />
        <!--moduleName=DSpellCheck.dll command=Spell Check Document Automatically-->
        <PluginCommand moduleName="DSpellCheck.dll" internalID="0" Ctrl="no" Alt="no" Shift="no" Key="0" />
    </PluginCommands>
    <ScintillaKeys>
        <!--SCI_CUT - Ctrl+X-->
        <ScintKey ScintID="2177" menuCmdID="42001" Ctrl="yes" Alt="no" Shift="no" Key="88">
            <!--SCI_CUT - Ctrl+X-->
            <NextKey Ctrl="no" Alt="no" Shift="yes" Key="46" />
        </ScintKey>
    </ScintillaKeys>
'''

