### PR TITLE
added `const` to several methods

### DIFF
--- a/PowerEditor/src/ScitillaComponent/AutoCompletion.cpp
+++ b/PowerEditor/src/ScitillaComponent/AutoCompletion.cpp
@@ -41,7 +41,7 @@ static bool isInList(generic_string word, const vector<generic_string> & wordArr
 };
 
 
-bool AutoCompletion::showApiComplete()
+bool AutoCompletion::showApiComplete() const
 {
 	if (!_funcCompletionActive)
 		return false;
@@ -114,7 +114,7 @@ bool AutoCompletion::showApiAndWordComplete()
 	return true;
 }
 
-void AutoCompletion::getWordArray(vector<generic_string> & wordArray, TCHAR *beginChars)
+void AutoCompletion::getWordArray(vector<generic_string> & wordArray, const TCHAR *beginChars) const
 {
 	const size_t bufSize = 256;
 
@@ -304,7 +304,7 @@ void AutoCompletion::showPathCompletion()
 	return;
 }
 
-bool AutoCompletion::showWordComplete(bool autoInsert)
+bool AutoCompletion::showWordComplete(bool autoInsert) const
 {
 	int curPos = int(_pEditView->execute(SCI_GETCURRENTPOS));
 	int startPos = int(_pEditView->execute(SCI_WORDSTARTPOSITION, curPos, true));
@@ -365,7 +365,7 @@ bool AutoCompletion::showFunctionComplete()
 	return false;
 }
 
-void AutoCompletion::getCloseTag(char *closeTag, size_t closeTagSize, size_t caretPos)
+void AutoCompletion::getCloseTag(char *closeTag, size_t closeTagSize, size_t caretPos) const
 {
 	int flags = SCFIND_REGEXP | SCFIND_POSIX;
 	_pEditView->execute(SCI_SETSEARCHFLAGS, flags);

--- a/PowerEditor/src/ScitillaComponent/AutoCompletion.h
+++ b/PowerEditor/src/ScitillaComponent/AutoCompletion.h
@@ -77,9 +77,9 @@ public:
 	bool setLanguage(LangType language);
 
 	//AutoComplete from the list
-	bool showApiComplete();
+	bool showApiComplete() const;
 	//WordCompletion from the current file
-	bool showWordComplete(bool autoInsert);	//autoInsert true if completion should fill in the word on a single match
+	bool showWordComplete(bool autoInsert) const;	//autoInsert true if completion should fill in the word on a single match
 	// AutoComplete from both the list and the current file
 	bool showApiAndWordComplete();
 	//Parameter display from the list
@@ -90,7 +90,7 @@ public:
 	void insertMatchedChars(int character, const MatchedPairConf & matchedPairConf);
 	void update(int character);
 	void callTipClick(int direction);
-	void getCloseTag(char *closeTag, size_t closeTagLen, size_t caretPos);
+	void getCloseTag(char *closeTag, size_t closeTagLen, size_t caretPos) const;
 
 private:
 	bool _funcCompletionActive;
@@ -110,7 +110,7 @@ private:
 	FunctionCallTip _funcCalltip;
 
 	const TCHAR * getApiFileName();
-	void getWordArray(vector<generic_string> & wordArray, TCHAR *beginChars);
+	void getWordArray(vector<generic_string> & wordArray, const TCHAR *beginChars) const;
 };
 
 #endif //AUTOCOMPLETION_H

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -1895,7 +1895,7 @@ int ScintillaEditView::replaceTargetRegExMode(const TCHAR * re, int fromTargetPo
 	return execute(SCI_REPLACETARGETRE, (WPARAM)-1, (LPARAM)reA);
 }
 
-void ScintillaEditView::showAutoComletion(int lenEntered, const TCHAR * list)
+void ScintillaEditView::showAutoComletion(int lenEntered, const TCHAR * list) const
 {
 	WcharMbcsConvertor *wmc = WcharMbcsConvertor::getInstance();
 	unsigned int cp = execute(SCI_GETCODEPAGE); 

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
@@ -268,7 +268,7 @@ public:
 	void addGenericText(const TCHAR * text2Append, long *mstart, long *mend) const;
 	int replaceTarget(const TCHAR * str2replace, int fromTargetPos = -1, int toTargetPos = -1) const;
 	int replaceTargetRegExMode(const TCHAR * re, int fromTargetPos = -1, int toTargetPos = -1) const;
-	void showAutoComletion(int lenEntered, const TCHAR * list);
+	void showAutoComletion(int lenEntered, const TCHAR * list) const;
 	void showCallTip(int startPos, const TCHAR * def);
 	void getLine(int lineNumber, TCHAR * line, int lineBufferLen);
 	void addText(int length, const char *buf);


### PR DESCRIPTION
Several methods were effectively const - they didn't modify their parameters - but they weren't marked const.

I simply marked them const. No functional changes.