### PR TITLE
Use precompiled headers correctly.

### DIFF
--- a/PowerEditor/src/MISC/Common/precompiledHeaders.h
+++ b/PowerEditor/src/MISC/Common/precompiledHeaders.h
@@ -44,6 +44,7 @@
 #include <time.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <tchar.h>
 
 // STL Headers
 #include <iostream>
@@ -54,7 +55,8 @@
 #include <map>
 #include <memory>
 #include <algorithm>
-#include <exception>	
+#include <exception>
+#include <stack>
 
 // Windows Header Files
 #include <windows.h>

--- a/PowerEditor/src/MISC/Common/precompiledHeaders.h
+++ b/PowerEditor/src/MISC/Common/precompiledHeaders.h
@@ -44,6 +44,8 @@
 #include <time.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <stddef.h>
+#include <assert.h>
 #include <tchar.h>
 
 // STL Headers
@@ -56,6 +58,7 @@
 #include <memory>
 #include <algorithm>
 #include <exception>
+#include <locale>
 #include <stack>
 
 // Windows Header Files
@@ -67,6 +70,8 @@
 #include <Oleacc.h>
 #include <dbghelp.h>
 #include <eh.h>
+#include <windowsx.h>
+#include <shellapi.h>
 
 #ifdef UNICODE
 #include <wchar.h>

--- a/PowerEditor/visual.net/notepadPlus.vcxproj
+++ b/PowerEditor/visual.net/notepadPlus.vcxproj
@@ -63,7 +63,7 @@
       <ExceptionHandling>Async</ExceptionHandling>
       <BasicRuntimeChecks>Default</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-      <PrecompiledHeader>Create</PrecompiledHeader>
+      <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>precompiledHeaders.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
       <WarningLevel>Level4</WarningLevel>
@@ -105,7 +105,7 @@
       <ExceptionHandling>Async</ExceptionHandling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
-      <PrecompiledHeader>Create</PrecompiledHeader>
+      <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>precompiledHeaders.h</PrecompiledHeaderFile>
       <WarningLevel>Level4</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
@@ -209,7 +209,10 @@ copy ..\src\contextMenu.xml ..\bin\contextMenu.xml
     <ClCompile Include="..\src\uchardet\nsUTF8Prober.cpp" />
     <ClCompile Include="..\src\Parameters.cpp" />
     <ClCompile Include="..\src\Misc\PluginsManager\PluginsManager.cpp" />
-    <ClCompile Include="..\src\MISC\Common\precompiledHeaders.cpp" />
+    <ClCompile Include="..\src\MISC\Common\precompiledHeaders.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Unicode Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Unicode Debug|Win32'">Create</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="..\src\WinControls\Preference\preferenceDlg.cpp" />
     <ClCompile Include="..\src\ScitillaComponent\Printer.cpp" />
     <ClCompile Include="..\src\MISC\Process\Process.cpp" />


### PR DESCRIPTION
Improve build speed.