### PR TITLE
Support compilation in VS2015.

### DIFF
--- a/PowerEditor/src/MISC/Common/precompiledHeaders.h
+++ b/PowerEditor/src/MISC/Common/precompiledHeaders.h
@@ -66,7 +66,7 @@
 #include <Oleacc.h>
 
 #pragma warning(push)
-#pragma warning(disable: 4091)
+#pragma warning(disable: 4091) // 'keyword' : ignored on left of 'type' when no variable is declared
 #include <dbghelp.h>
 #pragma warning(pop)
 #include <eh.h>

--- a/PowerEditor/src/MISC/Common/precompiledHeaders.h
+++ b/PowerEditor/src/MISC/Common/precompiledHeaders.h
@@ -32,6 +32,7 @@
 // w/o precompiled headers file : 1 minute 55 sec
 
 #define _WIN32_WINNT 0x0501
+#define _CRT_NON_CONFORMING_WCSTOK
 
 // C RunTime Header Files
 #include <stdio.h>
@@ -63,7 +64,11 @@
 #include <shlwapi.h>
 #include <uxtheme.h>
 #include <Oleacc.h>
+
+#pragma warning(push)
+#pragma warning(disable: 4091)
 #include <dbghelp.h>
+#pragma warning(pop)
 #include <eh.h>
 
 #ifdef UNICODE

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -2374,9 +2374,9 @@ void ScintillaEditView::convertSelectedTextTo(bool Case)
 			for (int j = 0 ; j < nbChar ; ++j)
 			{
 				if (Case == UPPERCASE)
-					destStr[j] = (wchar_t)::CharUpperW((LPWSTR)destStr[j]);
+					destStr[j] = (wchar_t)(UINT_PTR)::CharUpperW((LPWSTR)destStr[j]);
 				else
-					destStr[j] = (wchar_t)::CharLowerW((LPWSTR)destStr[j]);
+					destStr[j] = (wchar_t)(UINT_PTR)::CharLowerW((LPWSTR)destStr[j]);
 			}
 			::WideCharToMultiByte(codepage, 0, destStr, len, srcStr, len, NULL, NULL);
 
@@ -2414,9 +2414,9 @@ void ScintillaEditView::convertSelectedTextTo(bool Case)
 		for (int i = 0 ; i < nbChar ; ++i)
 		{
 			if (Case == UPPERCASE)
-				selectedStrW[i] = (WCHAR)::CharUpperW((LPWSTR)selectedStrW[i]);
+				selectedStrW[i] = (WCHAR)(UINT_PTR)::CharUpperW((LPWSTR)selectedStrW[i]);
 			else
-				selectedStrW[i] = (WCHAR)::CharLowerW((LPWSTR)selectedStrW[i]);
+				selectedStrW[i] = (WCHAR)(UINT_PTR)::CharLowerW((LPWSTR)selectedStrW[i]);
 		}
 		::WideCharToMultiByte(codepage, 0, selectedStrW, strWSize, selectedStr, strSize, NULL, NULL);
 

--- a/PowerEditor/src/TinyXml/tinyXmlA/tinyxmlA.h
+++ b/PowerEditor/src/TinyXml/tinyXmlA/tinyxmlA.h
@@ -27,6 +27,8 @@ distribution.
 #define TINYXMLA_INCLUDED
 
 #ifdef _MSC_VER
+#pragma warning( push )
+#pragma warning( disable : 4458 )
 #pragma warning( disable : 4530 )
 #pragma warning( disable : 4786 )
 #endif
@@ -1250,6 +1252,9 @@ private:
 	TiXmlNodeA* node;
 };
 
+#ifdef _MSC_VER
+#pragma warning( pop )
+#endif
 
 #endif
 

--- a/PowerEditor/src/TinyXml/tinyXmlA/tinyxmlA.h
+++ b/PowerEditor/src/TinyXml/tinyXmlA/tinyxmlA.h
@@ -28,7 +28,7 @@ distribution.
 
 #ifdef _MSC_VER
 #pragma warning( push )
-#pragma warning( disable : 4458 )
+#pragma warning( disable : 4458 ) // declaration of 'parameter' hides class member
 #pragma warning( disable : 4530 )
 #pragma warning( disable : 4786 )
 #endif

--- a/PowerEditor/src/TinyXml/tinyxml.h
+++ b/PowerEditor/src/TinyXml/tinyxml.h
@@ -28,7 +28,7 @@ distribution.
 
 #ifdef _MSC_VER
 #pragma warning( push )
-#pragma warning( disable : 4458 )
+#pragma warning( disable : 4458 ) // declaration of 'parameter' hides class member
 #pragma warning( disable : 4530 )
 #pragma warning( disable : 4786 )
 #endif

--- a/PowerEditor/src/TinyXml/tinyxml.h
+++ b/PowerEditor/src/TinyXml/tinyxml.h
@@ -27,6 +27,8 @@ distribution.
 #define TINYXML_INCLUDED
 
 #ifdef _MSC_VER
+#pragma warning( push )
+#pragma warning( disable : 4458 )
 #pragma warning( disable : 4530 )
 #pragma warning( disable : 4786 )
 #endif
@@ -1248,6 +1250,9 @@ private:
 	TiXmlNode* node;
 };
 
+#ifdef _MSC_VER
+#pragma warning( pop )
+#endif
 
 #endif
 

--- a/PowerEditor/visual.net/notepadPlus.vcxproj
+++ b/PowerEditor/visual.net/notepadPlus.vcxproj
@@ -69,6 +69,7 @@
       <WarningLevel>Level4</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <DisableSpecificWarnings>4456;4457;4459</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <AdditionalOptions>/fixed:no %(AdditionalOptions)</AdditionalOptions>
@@ -111,6 +112,7 @@
       <TreatWarningAsError>true</TreatWarningAsError>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
+      <DisableSpecificWarnings>4456;4457;4459</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;shlwapi.lib;shell32.lib;Oleacc.lib;%(AdditionalDependencies)</AdditionalDependencies>


### PR DESCRIPTION
Changes:
_CRT_NON_CONFORMING_WCSTOK - to have old wcstok behaviour
dbghelp.h doesn't disable warnings, do it manually.
Better casting from pointer to integral.
Disable warnings in tinyXml headers.
Disable warnings 4456;4457;4459 to not touch the source.
More details about the warnings: http://blogs.msdn.com/b/vcblog/archive/2014/11/12/improvements-to-warnings-in-the-c-compiler.aspx