### PR TITLE
Remove OPENFILENAMENPP structure

### DIFF
--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/FileDialog.cpp
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/FileDialog.cpp
@@ -172,7 +172,7 @@ TCHAR * FileDialog::doOpenSingleFileDlg()
 
 	TCHAR *fn = NULL;
 	try {
-		fn = ::GetOpenFileName((OPENFILENAME*)&_ofn)?_fileName:NULL;
+		fn = ::GetOpenFileName(&_ofn)?_fileName:NULL;
 		
 		if (params->getNppGUI()._openSaveDir == dir_last)
 		{
@@ -201,7 +201,7 @@ stringVector * FileDialog::doOpenMultiFilesDlg()
 
 	_ofn.Flags |= OFN_FILEMUSTEXIST | OFN_ALLOWMULTISELECT;
 
-	BOOL res = ::GetOpenFileName((OPENFILENAME*)&_ofn);
+	BOOL res = ::GetOpenFileName(&_ofn);
 	if (params->getNppGUI()._openSaveDir == dir_last)
 	{
 		::GetCurrentDirectory(MAX_PATH, dir);
@@ -253,7 +253,7 @@ TCHAR * FileDialog::doSaveDlg()
 
 	TCHAR *fn = NULL;
 	try {
-		fn = ::GetSaveFileName((OPENFILENAME*)&_ofn)?_fileName:NULL;
+		fn = ::GetSaveFileName(&_ofn)?_fileName:NULL;
 		if (params->getNppGUI()._openSaveDir == dir_last)
 		{
 			::GetCurrentDirectory(MAX_PATH, dir);

--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/FileDialog.h
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/FileDialog.h
@@ -36,33 +36,6 @@ using namespace std;
 
 typedef vector<generic_string> stringVector;
 
-struct OPENFILENAMENPP {
-   DWORD        lStructSize;
-   HWND         hwndOwner;
-   HINSTANCE    hInstance;
-   LPCTSTR      lpstrFilter;
-   LPTSTR       lpstrCustomFilter;
-   DWORD        nMaxCustFilter;
-   DWORD        nFilterIndex;
-   LPTSTR       lpstrFile;
-   DWORD        nMaxFile;
-   LPTSTR       lpstrFileTitle;
-   DWORD        nMaxFileTitle;
-   LPCTSTR      lpstrInitialDir;
-   LPCTSTR      lpstrTitle;
-   DWORD        Flags;
-   WORD         nFileOffset;
-   WORD         nFileExtension;
-   LPCTSTR      lpstrDefExt;
-   LPARAM       lCustData;
-   LPOFNHOOKPROC lpfnHook;
-   LPCTSTR      lpTemplateName;
-   void *		pvReserved;
-   DWORD        dwReserved;
-   DWORD        FlagsEx;
-};
-
-
 generic_string changeExt(generic_string fn, generic_string ext, bool forceReplaced = true);
 void goToCenter(HWND hwnd);
 
@@ -96,7 +69,7 @@ private:
 
 	stringVector _fileNames;
 
-	OPENFILENAMENPP _ofn;
+	OPENFILENAME _ofn;
 	winVer _winVersion;
 	
 


### PR DESCRIPTION
This struct appears to be an exact copy of Windows' OPENFILENAME struct. I don't see the point and it seems like it could cause all manner of strange issues if someone changed the NPP struct by accident.