### PR TITLE
Add jsm to the Javascript extensions

### DIFF
--- a/PowerEditor/src/langs.model.xml
+++ b/PowerEditor/src/langs.model.xml
@@ -110,7 +110,7 @@
             <Keywords name="instre1">instanceof assert if else switch case default break goto return for while do continue new throw throws try catch finally this super extends implements import true false null</Keywords>
             <Keywords name="type1">package transient strictfp void char short int long double float const static volatile byte boolean class interface native private protected public final abstract synchronized enum</Keywords>
         </Language>
-        <Language name="javascript" ext="js" commentLine="//" commentStart="/*" commentEnd="*/">
+        <Language name="javascript" ext="js jsm" commentLine="//" commentStart="/*" commentEnd="*/">
             <Keywords name="instre1">abstract boolean break byte case catch char class const continue debugger default delete do double else enum export extends final finally float for function goto if implements import in instanceof int interface long native new package private protected public return short static super switch synchronized this throw throws transient try typeof var void volatile while with true false prototype</Keywords>
         </Language>
         <Language name="jsp" ext="jsp" commentLine="//" commentStart="/*" commentEnd="*/"/>


### PR DESCRIPTION
.jsm is short for Javascript module and is at least used in Mozilla Addons for shared Javascript code.

By the way, perhaps you could get rid of this `encoding="Windows-1252"` at the beginning. UTF-8 is the way to go :)
_____________________
Off-Topic: Maybe it would be better if you create a notepad-plus-plus organisation. After all, I suppose it's likely that it won't end with just one repository, and with an organisation there is a better overview over all repos related to a project. For instance, you could publish the website, so people could help with the translations easier. [It's also possible to transfer repositories, and GitHub redirects from the old location to the new one so that's not a problem either].


