### PR TITLE
Prevent file corruption in some cases

### DIFF
--- a/PowerEditor/src/MISC/Common/LongRunningOperation.cpp
+++ b/PowerEditor/src/MISC/Common/LongRunningOperation.cpp
@@ -29,7 +29,7 @@
 #include "LongRunningOperation.h"
 #include <mutex>
 
-std::recursive_mutex _operationMutex;
+static std::recursive_mutex _operationMutex;
 
 LongRunningOperation::LongRunningOperation()
 {

--- a/PowerEditor/src/MISC/Common/LongRunningOperation.cpp
+++ b/PowerEditor/src/MISC/Common/LongRunningOperation.cpp
@@ -1,0 +1,42 @@
+// This file is part of Notepad++ project
+// Copyright (C)2003 Don HO <don.h@free.fr>
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either
+// version 2 of the License, or (at your option) any later version.
+//
+// Note that the GPL places important restrictions on "derived works", yet
+// it does not provide a detailed definition of that term.  To avoid      
+// misunderstandings, we consider an application to constitute a          
+// "derivative work" for the purpose of this license if it does any of the
+// following:                                                             
+// 1. Integrates source code from Notepad++.
+// 2. Integrates/includes/aggregates Notepad++ into a proprietary executable
+//    installer, such as those produced by InstallShield.
+// 3. Links to a library or executes a program that does any of the above.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+
+#include "LongRunningOperation.h"
+#include <mutex>
+
+std::recursive_mutex _operationMutex;
+
+LongRunningOperation::LongRunningOperation()
+{
+	_operationMutex.lock();
+}
+
+LongRunningOperation::~LongRunningOperation()
+{
+	_operationMutex.unlock();
+}

--- a/PowerEditor/src/MISC/Common/LongRunningOperation.h
+++ b/PowerEditor/src/MISC/Common/LongRunningOperation.h
@@ -1,0 +1,39 @@
+// This file is part of Notepad++ project
+// Copyright (C)2003 Don HO <don.h@free.fr>
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either
+// version 2 of the License, or (at your option) any later version.
+//
+// Note that the GPL places important restrictions on "derived works", yet
+// it does not provide a detailed definition of that term.  To avoid      
+// misunderstandings, we consider an application to constitute a          
+// "derivative work" for the purpose of this license if it does any of the
+// following:                                                             
+// 1. Integrates source code from Notepad++.
+// 2. Integrates/includes/aggregates Notepad++ into a proprietary executable
+//    installer, such as those produced by InstallShield.
+// 3. Links to a library or executes a program that does any of the above.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+
+#ifndef M30_IDE_LONGRUNNINGOPERATION_h
+#define M30_IDE_LONGRUNNINGOPERATION_h
+
+class LongRunningOperation
+{
+public:
+	LongRunningOperation();
+	~LongRunningOperation();
+};
+
+#endif //M30_IDE_LONGRUNNINGOPERATION_h

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -36,6 +36,7 @@
 #include "documentMap.h"
 #include "functionListPanel.h"
 #include "Sorters.h"
+#include "LongRunningOperation.h"
 
 
 void Notepad_plus::macroPlayback(Macro macro)
@@ -178,16 +179,22 @@ void Notepad_plus::command(int id)
 			break;
 
 		case IDM_EDIT_UNDO:
+		{
+			LongRunningOperation op;
 			_pEditView->execute(WM_UNDO);
 			checkClipboard();
 			checkUndoState();
 			break;
+		}
 
 		case IDM_EDIT_REDO:
+		{
+			LongRunningOperation op;
 			_pEditView->execute(SCI_REDO);
 			checkClipboard();
 			checkUndoState();
 			break;
+		}
 
 		case IDM_EDIT_CUT:
 			_pEditView->execute(WM_CUT);
@@ -354,6 +361,8 @@ void Notepad_plus::command(int id)
 		case IDM_EDIT_SORTLINES_DECIMALDOT_ASCENDING:
 		case IDM_EDIT_SORTLINES_DECIMALDOT_DESCENDING:
 		{
+			LongRunningOperation op;
+
 			size_t fromLine = 0, toLine = 0;
 			size_t fromColumn = 0, toColumn = 0;
 

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -267,6 +267,7 @@ void Notepad_plus::command(int id)
 
 		case IDM_EDIT_PASTE:
 		{
+			LongRunningOperation op;
 			int eolMode = int(_pEditView->execute(SCI_GETEOLMODE));
 			_pEditView->execute(SCI_PASTE);
 			_pEditView->execute(SCI_CONVERTEOLS, eolMode);
@@ -275,6 +276,7 @@ void Notepad_plus::command(int id)
 
 		case IDM_EDIT_PASTE_BINARY:
 		{			
+			LongRunningOperation op;
 			if (!IsClipboardFormatAvailable(CF_TEXT))
 				return;
 
@@ -319,6 +321,7 @@ void Notepad_plus::command(int id)
 		case IDM_EDIT_PASTE_AS_RTF:
 		case IDM_EDIT_PASTE_AS_HTML:
 		{
+			LongRunningOperation op;
 			UINT f = RegisterClipboardFormat(id==IDM_EDIT_PASTE_AS_HTML?CF_HTML:CF_RTF);
 
 			if (!IsClipboardFormatAvailable(f)) 

--- a/PowerEditor/src/ScitillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Buffer.cpp
@@ -34,6 +34,7 @@
 #include "ScintillaEditView.h"
 #include "EncodingMapper.h"
 #include "uchardet.h"
+#include "LongRunningOperation.h"
 
 FileManager * FileManager::_pSelf = new FileManager();
 
@@ -674,6 +675,8 @@ For untitled document (new  4)
 */
 bool FileManager::backupCurrentBuffer()
 {
+	LongRunningOperation op;
+
 	Buffer * buffer = _pNotepadPlus->getCurrentBuffer();
 	bool result = false;
 	bool hasModifForSession = false;

--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
@@ -31,6 +31,7 @@
 #include "ScintillaEditView.h"
 #include "Notepad_plus_msgs.h"
 #include "UniConversion.h"
+#include "LongRunningOperation.h"
 
 FindOption * FindReplaceDlg::_env;
 FindOption FindReplaceDlg::_options;
@@ -706,6 +707,7 @@ BOOL CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 
 				case IDREPLACE :
 				{
+					LongRunningOperation op;
 					if (_currentStatus == REPLACE_DLG)
 					{
 						setStatusbarMessage(TEXT(""), FSNoMessage);
@@ -792,6 +794,7 @@ BOOL CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 
 				case IDD_FINDINFILES_REPLACEINFILES :
 				{
+					LongRunningOperation op;
 					setStatusbarMessage(TEXT(""), FSNoMessage);
 					const int filterSize = 256;
 					TCHAR filters[filterSize];
@@ -832,6 +835,7 @@ BOOL CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 
 				case IDC_REPLACE_OPENEDFILES :
 				{
+					LongRunningOperation op;
 					if (_currentStatus == REPLACE_DLG)
 					{
 						setStatusbarMessage(TEXT(""), FSNoMessage);
@@ -852,6 +856,7 @@ BOOL CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 
 				case IDREPLACEALL :
 				{
+					LongRunningOperation op;
 					if (_currentStatus == REPLACE_DLG)
 					{
 						setStatusbarMessage(TEXT(""), FSNoMessage);

--- a/PowerEditor/visual.net/notepadPlus.vcxproj
+++ b/PowerEditor/visual.net/notepadPlus.vcxproj
@@ -138,6 +138,7 @@ copy ..\src\contextMenu.xml ..\bin\contextMenu.xml
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\src\MISC\Common\LongRunningOperation.cpp" />
     <ClCompile Include="..\src\WinControls\AboutDlg\AboutDlg.cpp" />
     <ClCompile Include="..\src\WinControls\AnsiCharPanel\ansiCharPanel.cpp" />
     <ClCompile Include="..\src\ScitillaComponent\AutoCompletion.cpp" />


### PR DESCRIPTION
1. Create a file with 100 000 GUIDs (any large file will do, really).
2. Open the file in Notepad++ and enable session snapshot.
3. Set backup time to 1 second.
4. Replace every "a" with "b" in the file.
5. Observe corruption (the CR/LFs):

![x](https://cloud.githubusercontent.com/assets/1019727/7814406/443d9d16-03c2-11e5-9fb2-15372e454327.png)

FileManager::backupCurrentBuffer() guards against being called at the same time from different threads, but it does nothing to prevent non-threadsafe access to Scintilla etc. 

In an ideal world, this feature would be turned off until it can be implemented safely (it looks like a lot of work to me, but maybe someone can think of an easy solution). I don't think that's going to happen, so as a *temporary* fix I've added a mutex which will prevent corruption in *some* cases (undo, redo, replace, sort).