### PR TITLE
remove try/catch block in doOpenSingleFileDlg

### DIFF
--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/FileDialog.cpp
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/FileDialog.cpp
@@ -161,7 +161,7 @@ int FileDialog::setExtsFilter(const TCHAR *extText, const TCHAR *exts)
 	return _nbExt;
 }
 
-TCHAR * FileDialog::doOpenSingleFileDlg() 
+_Ret_maybenull_z_ TCHAR* FileDialog::doOpenSingleFileDlg() 
 {
 	TCHAR dir[MAX_PATH];
 	::GetCurrentDirectory(MAX_PATH, dir);
@@ -170,19 +170,12 @@ TCHAR * FileDialog::doOpenSingleFileDlg()
 
 	_ofn.Flags |= OFN_FILEMUSTEXIST;
 
-	TCHAR *fn = NULL;
-	try {
-		fn = ::GetOpenFileName(&_ofn)?_fileName:NULL;
+	PTSTR fn = ::GetOpenFileName(&_ofn)?_fileName:NULL;
 		
-		if (params->getNppGUI()._openSaveDir == dir_last)
-		{
-			::GetCurrentDirectory(MAX_PATH, dir);
-			params->setWorkingDir(dir);
-		}
-	} catch(std::exception e) {
-		::MessageBoxA(NULL, e.what(), "Exception", MB_OK);
-	} catch(...) {
-		::MessageBox(NULL, TEXT("GetSaveFileName crashes!!!"), TEXT(""), MB_OK);
+	if (params->getNppGUI()._openSaveDir == dir_last)
+	{
+		::GetCurrentDirectory(MAX_PATH, dir);
+		params->setWorkingDir(dir);
 	}
 
 	::SetCurrentDirectory(dir); 

--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/FileDialog.h
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/FileDialog.h
@@ -52,7 +52,7 @@ public:
 
 	TCHAR * doSaveDlg();
 	stringVector * doOpenMultiFilesDlg();
-	TCHAR * doOpenSingleFileDlg();
+	_Ret_maybenull_z_ TCHAR * doOpenSingleFileDlg();
 	bool isReadOnly() {return _ofn.Flags & OFN_READONLY;};
     void setExtIndex(int extTypeIndex) {_extTypeIndex = extTypeIndex;};
 
@@ -62,7 +62,7 @@ protected :
     BOOL APIENTRY run(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
 private:
-	TCHAR _fileName[MAX_PATH*8];
+	_Field_z_ TCHAR _fileName[MAX_PATH*8];
 
 	TCHAR * _fileExt;
 	int _nbCharFileExt;


### PR DESCRIPTION
Now that we don't use `OPENFILENAMENPP` (as of a7e00affb4d19a699c6b7e5c8a6a3a1e5a5869f1), there's no way that `::GetOpenFileName` will cause an `SEH`/`C++` exception. The `try`/`catch` block is no longer necessary, and is actually wrong.