### PR TITLE
removed several redundant LPVOID casts

### DIFF
--- a/PowerEditor/src/Notepad_plus_Window.cpp
+++ b/PowerEditor/src/Notepad_plus_Window.cpp
@@ -75,9 +75,9 @@ void Notepad_plus_Window::init(HINSTANCE hInst, HWND parent, const TCHAR *cmdLin
 					_hParent,\
 					NULL,\
 					_hInst,\
-					(LPVOID)this); // pass the ptr of this instantiated object
-                                   // for retrieve it in Notepad_plus_Proc from 
-                                   // the CREATESTRUCT.lpCreateParams afterward.
+					this); // pass the ptr of this instantiated object
+                           // for retrieve it in Notepad_plus_Proc from 
+                           // the CREATESTRUCT.lpCreateParams afterward.
 
 	if (!_hSelf)
 	{

--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
@@ -2976,7 +2976,7 @@ HWND Progress::open(HWND hCallerWnd, const TCHAR* header)
 		_tcscpy_s(_header, _countof(_header), cDefaultHeader);
 
 	_hThread = ::CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)threadFunc,
-		(LPVOID)this, 0, NULL);
+		this, 0, NULL);
 	if (!_hThread)
 	{
 		::CloseHandle(_hActiveState);
@@ -3068,7 +3068,7 @@ int Progress::createProgressWindow()
 		WS_EX_TOOLWINDOW | WS_EX_OVERLAPPEDWINDOW | WS_EX_TOPMOST,
 		cClassName, _header, WS_POPUP | WS_CAPTION,
 		CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
-		NULL, NULL, _hInst, (LPVOID)this);
+		NULL, NULL, _hInst, this);
 	if (!_hwnd)
 		return -1;
 

--- a/PowerEditor/src/WinControls/ColourPicker/ColourPicker.cpp
+++ b/PowerEditor/src/WinControls/ColourPicker/ColourPicker.cpp
@@ -43,7 +43,7 @@ void ColourPicker::init(HINSTANCE hInst, HWND parent)
 					_hParent,
 					NULL,
 					_hInst,
-					(LPVOID)0);
+					NULL);
 	if (!_hSelf)
 	{
 		throw std::runtime_error("ColourPicker::init : CreateWindowEx() function return null");

--- a/PowerEditor/src/WinControls/DockingWnd/DockingManager.cpp
+++ b/PowerEditor/src/WinControls/DockingWnd/DockingManager.cpp
@@ -132,7 +132,7 @@ void DockingManager::init(HINSTANCE hInst, HWND hWnd, Window ** ppWin)
 					_hParent,
 					NULL,
 					_hInst,
-					(LPVOID)this);
+					this);
 
 	if (!_hSelf)
 	{

--- a/PowerEditor/src/WinControls/DockingWnd/DockingSplitter.cpp
+++ b/PowerEditor/src/WinControls/DockingWnd/DockingSplitter.cpp
@@ -113,7 +113,7 @@ void DockingSplitter::init(HINSTANCE hInst, HWND hWnd, HWND hMessage, UINT flags
 	/* create splitter windows and initialize it */
 	_hSelf = ::CreateWindowEx( 0, wc.lpszClassName, TEXT(""), WS_CHILD | WS_VISIBLE,
 								CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, 
-								_hParent, NULL, _hInst, (LPVOID)this);
+								_hParent, NULL, _hInst, this);
 
 	if (!_hSelf)
 	{

--- a/PowerEditor/src/WinControls/DockingWnd/Gripper.cpp
+++ b/PowerEditor/src/WinControls/DockingWnd/Gripper.cpp
@@ -156,7 +156,7 @@ void Gripper::startGrip(DockingCont* pCont, DockingManager* pDockMgr)
 					NULL,
 					NULL,
 					_hInst,
-					(LPVOID)this);
+					this);
 	hWndServer = _hSelf;
 
 	if (!_hSelf)

--- a/PowerEditor/src/WinControls/Grid/BabyGridWrapper.cpp
+++ b/PowerEditor/src/WinControls/Grid/BabyGridWrapper.cpp
@@ -47,5 +47,5 @@ void BabyGridWrapper::init(HINSTANCE hInst, HWND parent, int id)
 					_hParent,\
 					(HMENU)id,\
 					_hInst,\
-					(LPVOID)/*this*/NULL);
+					/*this*/NULL);
 }

--- a/PowerEditor/src/WinControls/ProjectPanel/TreeView.cpp
+++ b/PowerEditor/src/WinControls/ProjectPanel/TreeView.cpp
@@ -45,7 +45,7 @@ void TreeView::init(HINSTANCE hInst, HWND parent, int treeViewID)
                             _hParent, 
                             NULL, 
                             _hInst, 
-                            (LPVOID)0);
+                            NULL);
 
 	TreeView_SetItemHeight(_hSelf, CY_ITEMHEIGHT);
 

--- a/PowerEditor/src/WinControls/SplitterContainer/Splitter.cpp
+++ b/PowerEditor/src/WinControls/SplitterContainer/Splitter.cpp
@@ -194,7 +194,7 @@ void Splitter::init( HINSTANCE hInst, HWND hPere, int splitterSize,
 				_hParent,
 				NULL,
 				_hInst,
-				(LPVOID)this);
+				this);
 	
 	if (!_hSelf)
 	{

--- a/PowerEditor/src/WinControls/SplitterContainer/SplitterContainer.cpp
+++ b/PowerEditor/src/WinControls/SplitterContainer/SplitterContainer.cpp
@@ -81,7 +81,7 @@ void SplitterContainer::create(Window *pWin0, Window *pWin1, int splitterSize,
 					_hParent,
 					NULL,
 					_hInst,
-					(LPVOID)this);
+					this);
 
 	if (!_hSelf)
 	{


### PR DESCRIPTION
The standard guarantees that any pointer can implicitly convert to a `void` pointer, as long as they're both identically `const`/`volatile` qualified.

Casting to a `void` pointer hides bugs, and hinders readability.

This Pull Request removes several of these casts.