### PR TITLE
ScitillaComponent: Buffer: _currentStatus is used uninitialized in ctor

### DIFF
--- a/PowerEditor/src/ScitillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Buffer.cpp
@@ -60,10 +60,11 @@ Buffer::Buffer(FileManager * pManager, BufferID id, Document doc, DocFileStatus 
 	_userLangExt = TEXT("");
 	_fullPathName = TEXT("");
 	_fileName = NULL;
+	_currentStatus = type;
+
 	setFileName(fileName, ndds._lang);
 	updateTimeStamp();
 	checkFileState();
-	_currentStatus = type;
 	_isDirty = false;
 
 	_needLexer = false;	//new buffers do not need lexing, Scintilla takes care of that


### PR DESCRIPTION
The non-default constructor of the class Buffer calls the inner method
`checkFileState()`, using the private variable `_currentStatus` to determine
whether some checks on the file attached to the buffer are required or not.
However this variable is properly initialized _after_.