### PR TITLE
Fixed extra space when creating a new document

### DIFF
--- a/PowerEditor/src/ScitillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Buffer.cpp
@@ -1090,7 +1090,7 @@ BufferID FileManager::newEmptyDocument()
 {
 	generic_string newTitle = UNTITLED_STR;
 	TCHAR nb[10];
-	wsprintf(nb, TEXT(" %d"), nextUntitledNewNumber());
+	wsprintf(nb, TEXT("%d"), nextUntitledNewNumber());
 	newTitle += nb;
 
 	Document doc = (Document)_pscratchTilla->execute(SCI_CREATEDOCUMENT);	//this already sets a reference for filemanager


### PR DESCRIPTION
Fixed extra space between UNTITLED_STR and document number when creating a new document through the function FileManager::newEmptyDocument()