### PR TITLE
documentmap: ViewZoneDlg: fixed uninitialized variables

### DIFF
--- a/PowerEditor/src/WinControls/DocumentMap/documentMap.cpp
+++ b/PowerEditor/src/WinControls/DocumentMap/documentMap.cpp
@@ -440,9 +440,13 @@ BOOL CALLBACK ViewZoneDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lPara
         case WM_INITDIALOG :
 		{
 			_viewZoneCanvas = ::GetDlgItem(_hSelf, IDC_VIEWZONECANVAS);
-			::SetWindowLongPtrW(_viewZoneCanvas, GWL_USERDATA, reinterpret_cast<LONG>(this));
-			_canvasDefaultProc = reinterpret_cast<WNDPROC>(::SetWindowLongPtr(_viewZoneCanvas, GWL_WNDPROC, reinterpret_cast<LONG>(canvasStaticProc)));
-			return TRUE;
+			if (NULL != _viewZoneCanvas)
+			{
+				::SetWindowLongPtrW(_viewZoneCanvas, GWL_USERDATA, reinterpret_cast<LONG>(this));
+				_canvasDefaultProc = reinterpret_cast<WNDPROC>(::SetWindowLongPtr(_viewZoneCanvas, GWL_WNDPROC, reinterpret_cast<LONG>(canvasStaticProc)));
+				return TRUE;
+			}
+			break;
 		}
 
 		case WM_LBUTTONDOWN:
@@ -466,7 +470,7 @@ BOOL CALLBACK ViewZoneDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lPara
 
 		case WM_SIZE:
         {
-			if (_viewZoneCanvas)
+			if (NULL != _viewZoneCanvas)
 			{
 				int width = LOWORD(lParam);
 				int height = HIWORD(lParam);
@@ -479,8 +483,8 @@ BOOL CALLBACK ViewZoneDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lPara
 		{
 			//Have to perform the scroll first, because the first/last line do not get updated untill after the scroll has been parsed
 			::SendMessage(_hParent, DOCUMENTMAP_MOUSEWHEEL, wParam, lParam);
+			return TRUE;
 		}
-		return TRUE;
 
 		case WM_DESTROY :
 		{

--- a/PowerEditor/src/WinControls/DocumentMap/documentMap.h
+++ b/PowerEditor/src/WinControls/DocumentMap/documentMap.h
@@ -53,7 +53,7 @@ enum moveMode {
 class ViewZoneDlg : public StaticDialog
 {
 public :
-	ViewZoneDlg() : StaticDialog() {};
+	ViewZoneDlg() : StaticDialog(), _viewZoneCanvas(NULL), _canvasDefaultProc(nullptr), _higherY(0), _lowerY(0) {}
 
 	void doDialog();
 
@@ -63,7 +63,8 @@ public :
 	void drawZone(long hY, long lY) {
 		_higherY = hY;
 		_lowerY = lY;
-		::InvalidateRect(_viewZoneCanvas, NULL, TRUE);
+		if (NULL != _viewZoneCanvas)
+			::InvalidateRect(_viewZoneCanvas, NULL, TRUE);
 	};
 
 	int getViewerHeight() const {


### PR DESCRIPTION
The real problem is `_viewZoneCanvas`, which can be used unitialized by `drawZone`.